### PR TITLE
린트 import/prefer-default-export 옵션 off

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,7 @@
         "ts": "never",
         "tsx": "never"
       }
-    ]
+    ],
+    "import/prefer-default-export": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,11 +20,7 @@
     "ecmaVersion": 12,
     "sourceType": "module"
   },
-  "plugins": [
-    "react",
-    "@typescript-eslint",
-    "prettier"
-  ],
+  "plugins": ["react", "@typescript-eslint", "prettier"],
   "settings": {
     "import/resolver": {
       "node": {


### PR DESCRIPTION
<!-- 작업 내용이 무엇인지 적어주세요 -->
<!-- 작업이 여러개라면 ###을 이용해 문단 구분을 해주세요 -->
<!-- 관련 이슈가 있다면 추가해주세요 -->

## 작업 내용

린트 룰 옵션에서 ` import/prefer-default-export` 옵션을 off 했습니다.
export default로만 내보내는 것을 강제하는 옵션인데 개발 컨벤션과 맞지 않아서요 :)
