### PR TITLE
Mainpage layout 설정

### DIFF
--- a/src/common/styles/color.scss
+++ b/src/common/styles/color.scss
@@ -1,0 +1,7 @@
+$primary-color: #ffb84d;
+$secondary-color: #fffaf3;
+
+$gray-color: #f3f3f3;
+$lightgray-color: "#f5f5f5";
+
+$font-color: #939393;

--- a/src/common/styles/reset.scss
+++ b/src/common/styles/reset.scss
@@ -1,0 +1,158 @@
+/* http://meyerweb.com/eric/tools/css/reset/
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+@import "./color.scss";
+@import "./theme.scss";
+
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  border: 0;
+  font-size: 100%;
+  vertical-align: baseline;
+}
+
+/* HTML5 display-role reset for older browsers */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+
+body {
+  line-height: 1;
+}
+
+ol,
+ul {
+  list-style: none;
+}
+
+blockquote,
+q {
+  quotes: none;
+}
+
+blockquote {
+  &::before,
+  &::after {
+    content: '';
+    content: none;
+  }
+}
+
+q {
+  &::before,
+  &::after {
+    content: '';
+    content: none;
+  }
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+nav {
+  height: $header-height;
+  background-color: $gray-color;
+}
+
+main {
+  display: flex;
+  height: $content-height;
+  justify-content: center;
+}

--- a/src/common/styles/theme.scss
+++ b/src/common/styles/theme.scss
@@ -1,0 +1,3 @@
+$content-width: 1220px;
+$content-height: 85vh;
+$header-height: 15vh;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,7 @@
+import React, { ReactElement } from "react";
+
+function Header(): ReactElement {
+  return <nav></nav>;
+}
+
+export default Header;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { RecoilRoot } from "recoil";
 import App from "./App";
+import "@/common/styles/reset.scss";
 
 ReactDOM.render(
   <RecoilRoot>

--- a/src/pages/MainPage.scss
+++ b/src/pages/MainPage.scss
@@ -1,0 +1,22 @@
+@mixin sideWrapper() {
+  width: 600px;
+  height: 100%;
+}
+
+.container {
+  display: flex;
+  height: 100%;
+  gap: 20px;
+}
+
+.leftWrapper {
+  background-color: oldlace;
+
+  @include sideWrapper();
+}
+
+.rightWrapper {
+  background-color: darkseagreen;
+
+  @include sideWrapper();
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,10 +1,18 @@
 import React, { ReactElement } from "react";
+import Header from "@/components/common/Header";
+import styles from "./MainPage.scss";
 
 function MainPage(): ReactElement {
   return (
-    <div>
-      <div>Mainpage</div>
-    </div>
+    <>
+      <Header />
+      <main>
+        <div className={styles.container}>
+          <div className={styles.leftWrapper}> left </div>
+          <div className={styles.rightWrapper}> right </div>
+        </div>
+      </main>
+    </>
   );
 }
 


### PR DESCRIPTION
## Mainpage layout 설정

### 상세 작업 내용

- 예전에 썼던 reset.scss를 기본적인 요소만 추가했습니다. [참조](https://gist.github.com/hcatlin/1027867)
- 자주 쓰일 것 같은 color set을 추가했습니다. (너무 많은 color 참조를 줄 경우 힘드실 수도 있으니 활용도 있는 것들만 넣어뒀습니다.)
- 우선 header와 content를 `vh` 단위로 만들어 놨습니다.
    - 이 부분은 세로가 충분히 긴 경우 문제가 될 수 있지만 진혁님이 어떻게 header styling 작업을 하실 지 몰라서 대충의 레이아웃의 위치를 알고 가로 사이즈를 설정하기위함으로 바라봐주셨으면 좋겠습니다. (가로 사이즈에 대한 의견 주시면 감사합니다 ㅎㅎ 저는 1440*900에 가장 잘맞는 사이즈를 눈대중으로 봤어요...)

![image](https://user-images.githubusercontent.com/33643752/145715350-48238144-9a33-4c01-ae69-d5fe7968237e.png)


## 기타

- 자주 쓰일 것 같은 color set을 추가했습니다.
   - 너무 많은 color 참조를 줄 경우 힘드실 수도 있으니 활용도 있는 것들만 넣어뒀습니다.

## 관련 이슈

closed #26 